### PR TITLE
Update myfox-security-system.ts

### DIFF
--- a/src/accessories/myfox-security-system.ts
+++ b/src/accessories/myfox-security-system.ts
@@ -20,7 +20,7 @@ export class MyfoxSecuritySystem {
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, this.site.brand)
       .setCharacteristic(this.platform.Characteristic.Model, 'HC2')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.site.siteId);
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.site.siteId.toString());
 
     this.service = this.accessory.getService(this.platform.Service.SecuritySystem)
       ?? this.accessory.addService(this.platform.Service.SecuritySystem);


### PR DESCRIPTION
Fixed a recurring warning for the SiteID identifier expected to be a string, but returned from API as an integer. added a simple toString() conversion. Warning Message is:

"This plugin generated a warning from the characteristic 'Serial Number': characteristic was supplied illegal value: number instead of string, supplying illegal values will throw errors in the future. See https://homebridge.io/w/JtMGR for more info."

Note: I'm not a TS or JS specialist, I just did this quick hack to get it converted. If there's a more elegant way, feel free to update !